### PR TITLE
Move CSS to separate output files

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "eslint-loader": "^1.0.0",
     "eslint-plugin-react": "^3.5.1",
     "express": "^4.13.3",
+    "extract-text-webpack-plugin": "brenoc/extract-text-webpack-plugin",
     "file-loader": "^0.8.1",
     "http-proxy": "^1.11.2",
     "loader-utils": "^0.2.6",

--- a/storefront/components/Banner.json
+++ b/storefront/components/Banner.json
@@ -1,6 +1,8 @@
 {
   "assets": [
     "Banner.js",
-    "editors/index.js"
+    "Banner.css",
+    "editors/index.js",
+    "editors/index.css"
   ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -119,8 +119,9 @@ var config = {
 };
 
 if (process.env.HOT) {
-  config.devtool = 'source-map';
-  config.entry['editors/index'].unshift('webpack-hot-middleware/client');
+  for (entryName in config.entry) {
+    config.entry[entryName].unshift('webpack-hot-middleware/client');
+  }
   config.plugins.unshift(new webpack.NoErrorsPlugin());
   config.plugins.unshift(new webpack.HotModuleReplacementPlugin());
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 var webpack = require('webpack');
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var path = require('path');
 var pkg = require('./package.json');
 var meta = require('./meta.json');
@@ -33,12 +34,12 @@ var config = {
         }
       }, {
         test: /\.scss$/,
-        loaders: production ?
-          ['style', 'css', 'sass'] :
-          ['style', 'css?sourceMap', 'sass?sourceMap']
+        loader: production ?
+          ExtractTextPlugin.extract('style', 'css!sass') :
+          ExtractTextPlugin.extract('style', 'css?sourceMap!sass?sourceMap')
       }, {
         test: /\.css$/,
-        loaders: ['style', 'css']
+        loader: ExtractTextPlugin.extract('style', 'css')
       }, {
         test: /\.svg$/,
         loaders: ['raw-loader', 'svgo-loader?' + JSON.stringify({
@@ -61,9 +62,11 @@ var config = {
   plugins: production ? [
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.optimize.UglifyJsPlugin({compressor: {warnings: false}}),
-    new webpack.optimize.AggressiveMergingPlugin()
+    new webpack.optimize.AggressiveMergingPlugin(),
+    new ExtractTextPlugin('[name].css')
   ] : [
-    new webpack.optimize.OccurenceOrderPlugin()
+    new webpack.optimize.OccurenceOrderPlugin(),
+    new ExtractTextPlugin('[name].css')
   ],
 
   externals: {
@@ -102,7 +105,7 @@ var config = {
     configFile: '.eslintrc'
   },
 
-  devtool: 'source-map',
+  devtool: production ? null : 'source-map',
 
   watch: production ? false : true,
 


### PR DESCRIPTION
Use ExtractTextPlugin to generate separate files for CSS.

Advantages:
- CSS cached separate
- CSS request in parallel
- Faster runtime
- Significantly smaller files

Decrease total size from 45.3kb to 26.4kb, huge improvement here!